### PR TITLE
Add Apotheneum chapter preview images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ devDependency), e.g. `tsx scripts/verify-chapter-videos.ts` via the `verify:medi
 - Never commit video masters (`*.mp4` / `*.mov` are ignored). Store them in the Cloudflare R2 bucket `danoved-media` and refer to object keys through `mediaUrl()` in `src/api/media.ts`.
 - Do not hardcode a media host in page code. The public base is `NEXT_PUBLIC_MEDIA_BASE_URL`; its production value is `https://media.danoved.xyz`. The r2.dev address remains the deliberate fallback for development/recovery.
 - R2 video objects are immutable. A changed export needs a new, versioned object key, not an overwrite.
-- A `ChapterVideo` must make no MP4 request before a visitor clicks: no `src`, no native `poster`, `preload="none"`, and assign/play the source synchronously from the click handler. Validate with `pnpm build && pnpm verify:media`.
+- A `ClickToPlayVideo` must make no MP4 request before a visitor clicks: no `src`, no native `poster`, `preload="none"`, and assign/play the source synchronously from the click handler. Validate with `pnpm build && pnpm verify:media`.
 
 ## Institutional memory
 

--- a/docs/media-pipeline.md
+++ b/docs/media-pipeline.md
@@ -75,7 +75,45 @@ Rules that go with that approach:
 - The multipart parts are set on the completed object with the same `content-type` and
   `cache-control` as the single-part path, so both routes produce identical objects.
 
-## 3. Verify public delivery
+## 3. Extract and upload preview images
+
+Each chapter's facade shows a first-frame still instead of the native `<video poster>` attribute
+(the component renders it as a plain `<img>` — see [How the player
+behaves](#how-the-player-behaves)), so it needs its own file:
+
+- **Extract frame zero** from the finished export, not an intermediate — the still must match what
+  playback actually starts on:
+
+  ```sh
+  ffmpeg -i chapter.mp4 -frames:v 1 -f image2 chapter-first-frame.avif
+  ```
+
+- **AVIF**, not JPEG/PNG: the facade is a single still shown at typical hero-video sizes, and AVIF
+  gives noticeably smaller files at equivalent quality, which matters because — unlike the MP4 —
+  this file loads on every page view, not just on click.
+
+- **Upload it like the video**, with the matching content type:
+
+  ```sh
+  pnpm exec wrangler r2 object put \
+    danoved-media/apotheneum/previews/03-rain-first-frame-v1.avif \
+    --file=./exports/03-rain-first-frame.avif \
+    --content-type=image/avif \
+    --cache-control="public, max-age=31536000, immutable" \
+    --remote
+  ```
+
+- **Object keys are versioned** the same way and for the same reason as the videos: previews live
+  under `apotheneum/previews/`, named `<NN>-<chapter>-first-frame-v<N>.avif`, and a re-extracted
+  still bumps the version rather than overwriting an `immutable` object.
+
+- **Link it in `chapters.ts`**: pass the preview's object key to the `chapter()` helper, which
+  builds the `previewImage` URL through `mediaUrl()` — never hardcode the media host. `ChapterVideo`
+  renders `previewImage` inside the clickable facade as an `<img>` with an alt describing the still
+  (e.g. `First frame of "<title>"`), not the button's own accessible name, and never assigns it to
+  the native `<video poster>` attribute.
+
+## 4. Verify public delivery
 
 Range support is what makes seeking work. Check it against the public URL, not the API:
 
@@ -93,31 +131,30 @@ Expect:
 
 All five current objects were verified this way against `media.danoved.xyz`; byte-range delivery is working publicly. The r2.dev URL is useful as a fallback diagnostic endpoint.
 
-## 4. Point the site at the media host
+## 5. Point the site at the media host
 
 - `media.danoved.xyz` is connected to the bucket and `NEXT_PUBLIC_MEDIA_BASE_URL=https://media.danoved.xyz` is set for Netlify production builds.
 - `NEXT_PUBLIC_*` values are inlined at build time, so changing this value requires a production redeploy; no code change is needed.
 
-## 5. Add or update a chapter
+## 6. Add or update a chapter
 
-1. Add the object key to `src/pages/portfolio/apotheneum/chapters.ts` with its title and runtime.
-   URLs are built from the key by `mediaUrl()` — never hardcode a host.
+1. Add the video object key and the preview-image object key (see [Extract and upload preview
+   images](#3-extract-and-upload-preview-images)) to `src/pages/portfolio/apotheneum/chapters.ts`
+   with the chapter's title and runtime. URLs are built from both keys by `mediaUrl()` — never
+   hardcode a host.
 2. Drop `<ChapterVideo {...chapters.<id>} />` into `index.mdx` under the matching prose section.
 3. Nothing else: `src/api/llmsContent.ts` picks the tag up and renders it into `/llms-full.txt` as
    a readable `[Video: Title (runtime) — url]` reference.
 
-Posters are optional and none exist yet. When one is added, upload it beside the video, set
-`poster` on the chapter, and it will lazy-load behind the facade — it never blocks first paint.
-
 ## Current object keys
 
-| Chapter id     | Object key                        | Runtime |
-| -------------- | --------------------------------- | ------- |
-| `hyperspace`   | `apotheneum/01-hyperspace-v2.mp4` | 5:10    |
-| `night-chorus` | `apotheneum/02-night-chorus.mp4`  | 4:06    |
-| `rain`         | `apotheneum/03-rain.mp4`          | 3:09    |
-| `thunderstorm` | `apotheneum/04-thunderstorm.mp4`  | 3:07    |
-| `sunrise`      | `apotheneum/05-sunrise.mp4`       | 3:48    |
+| Chapter id     | Video object key                  | Preview image object key                                  | Runtime |
+| -------------- | --------------------------------- | --------------------------------------------------------- | ------- |
+| `hyperspace`   | `apotheneum/01-hyperspace-v2.mp4` | `apotheneum/previews/01-hyperspace-first-frame-v1.avif`   | 5:10    |
+| `night-chorus` | `apotheneum/02-night-chorus.mp4`  | `apotheneum/previews/02-night-chorus-first-frame-v1.avif` | 4:06    |
+| `rain`         | `apotheneum/03-rain.mp4`          | `apotheneum/previews/03-rain-first-frame-v1.avif`         | 3:09    |
+| `thunderstorm` | `apotheneum/04-thunderstorm.mp4`  | `apotheneum/previews/04-thunderstorm-first-frame-v1.avif` | 3:07    |
+| `sunrise`      | `apotheneum/05-sunrise.mp4`       | `apotheneum/previews/05-sunrise-first-frame-v1.avif`      | 3:48    |
 
 ## How the player behaves
 
@@ -127,3 +164,9 @@ facade. The click handler assigns `video.src` and calls `video.play()` synchrono
 user-gesture stack (required by mobile Safari), moves focus to the native controls, and hides the
 facade once playback actually starts. Starting one chapter pauses any other on the page. If the
 file fails to load, the player offers a direct link to the MP4.
+
+The facade itself shows the `previewImage` still (see [Extract and upload preview
+images](#3-extract-and-upload-preview-images)) as a normal, lazily-loaded `<img>` — never the
+native `<video poster>` attribute, which would count as a video request before the click. The image
+gets its own descriptive alt text (the frame, not the action) so it isn't announced as a duplicate
+of the play button's accessible name.

--- a/docs/media-pipeline.md
+++ b/docs/media-pipeline.md
@@ -108,10 +108,10 @@ behaves](#how-the-player-behaves)), so it needs its own file:
   still bumps the version rather than overwriting an `immutable` object.
 
 - **Link it in `chapters.ts`**: pass the preview's object key to the `chapter()` helper, which
-  builds the `previewImage` URL through `mediaUrl()` — never hardcode the media host. `ChapterVideo`
-  renders `previewImage` inside the clickable facade as an `<img>` with an alt describing the still
-  (e.g. `First frame of "<title>"`), not the button's own accessible name, and never assigns it to
-  the native `<video poster>` attribute.
+  builds the `previewImage` URL through `mediaUrl()` — never hardcode the media host.
+  `ClickToPlayVideo` renders `previewImage` inside the clickable facade as an `<img>` with an alt
+  describing the still (e.g. `First frame of "<title>"`), not the button's own accessible name,
+  and never assigns it to the native `<video poster>` attribute.
 
 ## 4. Verify public delivery
 
@@ -142,7 +142,7 @@ All five current objects were verified this way against `media.danoved.xyz`; byt
    images](#3-extract-and-upload-preview-images)) to `src/pages/portfolio/apotheneum/chapters.ts`
    with the chapter's title and runtime. URLs are built from both keys by `mediaUrl()` — never
    hardcode a host.
-2. Drop `<ChapterVideo {...chapters.<id>} />` into `index.mdx` under the matching prose section.
+2. Drop `<ClickToPlayVideo {...chapters.<id>} />` into `index.mdx` under the matching prose section.
 3. Nothing else: `src/api/llmsContent.ts` picks the tag up and renders it into `/llms-full.txt` as
    a readable `[Video: Title (runtime) — url]` reference.
 
@@ -158,7 +158,7 @@ All five current objects were verified this way against `media.danoved.xyz`; byt
 
 ## How the player behaves
 
-`src/components/ChapterVideo.tsx` makes **zero** MP4 requests until a visitor clicks play: the
+`src/components/ClickToPlayVideo.tsx` makes **zero** MP4 requests until a visitor clicks play: the
 `<video>` is mounted with `preload="none"` and no `src` and no `poster` attribute, covered by a CSS
 facade. The click handler assigns `video.src` and calls `video.play()` synchronously in the same
 user-gesture stack (required by mobile Safari), moves focus to the native controls, and hides the

--- a/scripts/verify-chapter-videos.ts
+++ b/scripts/verify-chapter-videos.ts
@@ -18,23 +18,28 @@ const check = (ok: boolean, message: string): void => {
   if (!ok) failures.push(message);
 };
 
-type ExpectedChapter = [id: string, key: string, duration: string];
+type ExpectedChapter = [id: string, key: string, duration: string, previewKey: string];
 
 const EXPECTED: ExpectedChapter[] = [
-  ['hyperspace', 'apotheneum/01-hyperspace-v2.mp4', '5:10'],
-  ['night-chorus', 'apotheneum/02-night-chorus.mp4', '4:06'],
-  ['rain', 'apotheneum/03-rain.mp4', '3:09'],
-  ['thunderstorm', 'apotheneum/04-thunderstorm.mp4', '3:07'],
-  ['sunrise', 'apotheneum/05-sunrise.mp4', '3:48'],
+  ['hyperspace', 'apotheneum/01-hyperspace-v2.mp4', '5:10', 'apotheneum/previews/01-hyperspace-first-frame-v1.avif'],
+  ['night-chorus', 'apotheneum/02-night-chorus.mp4', '4:06', 'apotheneum/previews/02-night-chorus-first-frame-v1.avif'],
+  ['rain', 'apotheneum/03-rain.mp4', '3:09', 'apotheneum/previews/03-rain-first-frame-v1.avif'],
+  ['thunderstorm', 'apotheneum/04-thunderstorm.mp4', '3:07', 'apotheneum/previews/04-thunderstorm-first-frame-v1.avif'],
+  ['sunrise', 'apotheneum/05-sunrise.mp4', '3:48', 'apotheneum/previews/05-sunrise-first-frame-v1.avif'],
 ];
 
 // 1. Chapter metadata is the single source of truth, and hosts are never hardcoded.
 const chapters = read('src/pages/portfolio/apotheneum/chapters.ts');
-for (const [id, key, duration] of EXPECTED) {
+for (const [id, key, duration, previewKey] of EXPECTED) {
   check(chapters.includes(`'${key}'`), `chapters.ts is missing object key ${key}`);
   check(chapters.includes(`'${duration}'`), `chapters.ts is missing duration ${duration} (${id})`);
+  check(chapters.includes(`'${previewKey}'`), `chapters.ts is missing preview image key ${previewKey} (${id})`);
 }
 check(!/https?:\/\//.test(chapters), 'chapters.ts hardcodes a URL — build it from mediaUrl() instead');
+check(
+  chapters.includes('previewImage: mediaUrl('),
+  'chapters.ts must build previewImage from mediaUrl(), not hardcode it'
+);
 
 const media = read('src/api/media.ts');
 check(media.includes('NEXT_PUBLIC_MEDIA_BASE_URL'), 'media.ts no longer reads NEXT_PUBLIC_MEDIA_BASE_URL');
@@ -55,13 +60,28 @@ check(player.includes('preload="none"'), 'ChapterVideo lost preload="none"');
 check(!/<video[^>]*\ssrc=/.test(player), 'ChapterVideo renders a src attribute on <video>');
 check(!/<video[^>]*\sposter=/.test(player), 'ChapterVideo renders a native poster attribute');
 check(!player.includes('crossOrigin'), 'ChapterVideo sets crossOrigin');
-check(player.includes('loading="lazy"'), 'the optional poster image is no longer lazy');
+check(player.includes('loading="lazy"'), 'the preview image is no longer lazy');
 check(
   player.includes('tabIndex={showFacade ? -1 : undefined}'),
   'the hidden native player can enter keyboard tab order before activation'
 );
 
-// 4. llms.txt renders chapter references instead of stripping them.
+// 4. The preview image renders in the clickable facade, not on the <video>, with a label that
+// describes the image rather than repeating the button's accessible name.
+check(player.includes('previewImage'), 'ChapterVideo no longer accepts a previewImage prop');
+check(/<img\b[^>]*\bsrc=\{previewImage\}/.test(player), 'ChapterVideo does not render previewImage as an <img>');
+check(!/<img\b[^>]*\salt=""/.test(player), 'the preview image has an empty alt — it must carry a useful label');
+check(
+  !/<img\b[^>]*\baria-hidden="true"/.test(player),
+  'the preview image is hidden from assistive tech — it should be announced, not the decorative fallback'
+);
+check(
+  /<img\b[^>]*\balt=\{`[^`]*\$\{title\}[^`]*`\}/.test(player),
+  'the preview image alt text should describe the frame (and reference the chapter title) without repeating "Play …"'
+);
+check(!/\balt=\{`Play /.test(player), "the preview image alt text duplicates the play button's accessible name");
+
+// 5. llms.txt renders chapter references instead of stripping them.
 const llms = read('src/api/llmsContent.ts');
 const convertIndex = llms.indexOf('<ChapterVideo');
 const stripIndex = llms.indexOf('[A-Z]\\w+\\s+[\\s\\S]*?');
@@ -69,7 +89,8 @@ check(convertIndex !== -1, 'llmsContent.ts no longer converts ChapterVideo tags'
 check(stripIndex === -1 || convertIndex < stripIndex, 'ChapterVideo conversion must run before the generic JSX strip');
 check(llms.includes('(?!ChapterVideo\\b)'), 'the generic JSX strip lost its ChapterVideo guard');
 
-// 5. If a build is present, the prerendered DOM must contain no MP4 at all.
+// 6. If a build is present, the prerendered DOM must contain no MP4 at all, and the preview image
+// (loaded eagerly, unlike the video) must be present with a src built from the media host.
 const html = '.next/server/pages/portfolio/apotheneum.html';
 if (existsSync(join(root, html))) {
   const rendered = read(html);
@@ -80,6 +101,10 @@ if (existsSync(join(root, html))) {
     videos.every((tag) => !/\ssrc=/.test(tag) && !/\sposter=/.test(tag)),
     'a prerendered <video> carries a src or poster attribute'
   );
+
+  for (const [id, , , previewKey] of EXPECTED) {
+    check(rendered.includes(previewKey), `prerendered HTML is missing the preview image for "${id}" (${previewKey})`);
+  }
 } else {
   console.log(`(skipped prerender checks — ${html} not found; run \`pnpm build\` first)`);
 }

--- a/scripts/verify-chapter-videos.ts
+++ b/scripts/verify-chapter-videos.ts
@@ -44,22 +44,22 @@ check(
 const media = read('src/api/media.ts');
 check(media.includes('NEXT_PUBLIC_MEDIA_BASE_URL'), 'media.ts no longer reads NEXT_PUBLIC_MEDIA_BASE_URL');
 
-// 2. Exactly one <ChapterVideo /> per chapter in the article, and the YouTube overview is intact.
+// 2. Exactly one <ClickToPlayVideo /> per chapter in the article, and the YouTube overview is intact.
 const mdx = read('src/pages/portfolio/apotheneum/index.mdx');
-const embeds = mdx.match(/<ChapterVideo\b[^>]*\/>/g) ?? [];
-check(embeds.length === EXPECTED.length, `expected ${EXPECTED.length} ChapterVideo embeds, found ${embeds.length}`);
+const embeds = mdx.match(/<ClickToPlayVideo\b[^>]*\/>/g) ?? [];
+check(embeds.length === EXPECTED.length, `expected ${EXPECTED.length} ClickToPlayVideo embeds, found ${embeds.length}`);
 for (const [id] of EXPECTED) {
   const uses = embeds.filter((tag) => tag.includes(`chapters.${id}`) || tag.includes(`chapters['${id}']`));
-  check(uses.length === 1, `expected exactly one ChapterVideo for "${id}", found ${uses.length}`);
+  check(uses.length === 1, `expected exactly one ClickToPlayVideo for "${id}", found ${uses.length}`);
 }
 check(/<YouTube videoId="lkWg-qsuenw" \/>/.test(mdx), 'the YouTube overview embed was modified');
 
 // 3. The player never ships an eager source.
-const player = read('src/components/ChapterVideo.tsx');
-check(player.includes('preload="none"'), 'ChapterVideo lost preload="none"');
-check(!/<video[^>]*\ssrc=/.test(player), 'ChapterVideo renders a src attribute on <video>');
-check(!/<video[^>]*\sposter=/.test(player), 'ChapterVideo renders a native poster attribute');
-check(!player.includes('crossOrigin'), 'ChapterVideo sets crossOrigin');
+const player = read('src/components/ClickToPlayVideo.tsx');
+check(player.includes('preload="none"'), 'ClickToPlayVideo lost preload="none"');
+check(!/<video[^>]*\ssrc=/.test(player), 'ClickToPlayVideo renders a src attribute on <video>');
+check(!/<video[^>]*\sposter=/.test(player), 'ClickToPlayVideo renders a native poster attribute');
+check(!player.includes('crossOrigin'), 'ClickToPlayVideo sets crossOrigin');
 check(player.includes('loading="lazy"'), 'the preview image is no longer lazy');
 check(
   player.includes('tabIndex={showFacade ? -1 : undefined}'),
@@ -68,8 +68,8 @@ check(
 
 // 4. The preview image renders in the clickable facade, not on the <video>, with a label that
 // describes the image rather than repeating the button's accessible name.
-check(player.includes('previewImage'), 'ChapterVideo no longer accepts a previewImage prop');
-check(/<img\b[^>]*\bsrc=\{previewImage\}/.test(player), 'ChapterVideo does not render previewImage as an <img>');
+check(player.includes('previewImage'), 'ClickToPlayVideo no longer accepts a previewImage prop');
+check(/<img\b[^>]*\bsrc=\{previewImage\}/.test(player), 'ClickToPlayVideo does not render previewImage as an <img>');
 check(!/<img\b[^>]*\salt=""/.test(player), 'the preview image has an empty alt — it must carry a useful label');
 check(
   !/<img\b[^>]*\baria-hidden="true"/.test(player),
@@ -83,11 +83,14 @@ check(!/\balt=\{`Play /.test(player), "the preview image alt text duplicates the
 
 // 5. llms.txt renders chapter references instead of stripping them.
 const llms = read('src/api/llmsContent.ts');
-const convertIndex = llms.indexOf('<ChapterVideo');
+const convertIndex = llms.indexOf('<ClickToPlayVideo');
 const stripIndex = llms.indexOf('[A-Z]\\w+\\s+[\\s\\S]*?');
-check(convertIndex !== -1, 'llmsContent.ts no longer converts ChapterVideo tags');
-check(stripIndex === -1 || convertIndex < stripIndex, 'ChapterVideo conversion must run before the generic JSX strip');
-check(llms.includes('(?!ChapterVideo\\b)'), 'the generic JSX strip lost its ChapterVideo guard');
+check(convertIndex !== -1, 'llmsContent.ts no longer converts ClickToPlayVideo tags');
+check(
+  stripIndex === -1 || convertIndex < stripIndex,
+  'ClickToPlayVideo conversion must run before the generic JSX strip'
+);
+check(llms.includes('(?!ClickToPlayVideo\\b)'), 'the generic JSX strip lost its ClickToPlayVideo guard');
 
 // 6. If a build is present, the prerendered DOM must contain no MP4 at all, and the preview image
 // (loaded eagerly, unlike the video) must be present with a src built from the media host.

--- a/scripts/verify-chapter-videos.ts
+++ b/scripts/verify-chapter-videos.ts
@@ -93,7 +93,7 @@ check(
 check(llms.includes('(?!ClickToPlayVideo\\b)'), 'the generic JSX strip lost its ClickToPlayVideo guard');
 
 // 6. If a build is present, the prerendered DOM must contain no MP4 at all, and the preview image
-// (loaded eagerly, unlike the video) must be present with a src built from the media host.
+// (lazily loaded, unlike the video which waits for a click) must have a src built from the media host.
 const html = '.next/server/pages/portfolio/apotheneum.html';
 if (existsSync(join(root, html))) {
   const rendered = read(html);

--- a/src/api/llmsContent.ts
+++ b/src/api/llmsContent.ts
@@ -6,18 +6,19 @@ import { chapters as apotheneumChapters, Chapter } from '@/pages/portfolio/apoth
 const SITE_URL = 'https://danoved.xyz';
 
 /**
- * Chapter metadata keyed by id, so a <ChapterVideo /> tag in MDX can be rendered as a readable
+ * Chapter metadata keyed by id, so a <ClickToPlayVideo /> tag in MDX can be rendered as a readable
  * reference (title, runtime, direct MP4 URL) instead of being stripped as anonymous JSX.
  */
 const chapterVideos: Record<string, Chapter> = { ...apotheneumChapters };
 
 /**
- * MDX writes these as `<ChapterVideo {...chapters.rain} />` or `<ChapterVideo id="rain" />`.
+ * MDX writes these as `<ClickToPlayVideo {...chapters.rain} />` or
+ * `<ClickToPlayVideo id="rain" />`.
  * `[^>]*` keeps the match inside a single self-closing tag even when attributes span lines, so it
  * can never run past the tag the way a `[\s\S]*?` match could.
  */
-function convertChapterVideos(content: string): string {
-  return content.replace(/<ChapterVideo\b[^>]*\/>/g, (tag) => {
+function convertClickToPlayVideos(content: string): string {
+  return content.replace(/<ClickToPlayVideo\b[^>]*\/>/g, (tag) => {
     const spreadMatch = tag.match(/\bchapters(?:\.(\w+)|\[['"]([^'"]+)['"]\])/);
     const id = spreadMatch?.slice(1).find(Boolean) ?? tag.match(/\bid="([^"]+)"/)?.[1];
     if (!id) return '';
@@ -43,10 +44,10 @@ function formatLinks(links: MetaWithSlug['links']): string {
 }
 
 function cleanMdxContent(raw: string): string {
-  const withChapterVideos = convertChapterVideos(raw);
+  const withClickToPlayVideos = convertClickToPlayVideos(raw);
 
   return (
-    withChapterVideos
+    withClickToPlayVideos
       .split('\n')
       // Remove import lines
       .filter((line) => !line.match(/^import\s+/))
@@ -62,9 +63,9 @@ function cleanMdxContent(raw: string): string {
       // Remove Instagram embeds
       .replace(/<Instagram\s+[^/]*\/>/g, '')
       // Remove ResizedImageWithCaption and other self-closing JSX components.
-      // ChapterVideo is excluded: it is converted above, and this pattern spans newlines, so without
-      // the guard it could swallow a chapter reference (or the prose between two of them).
-      .replace(/<(?!ChapterVideo\b)[A-Z]\w+\s+[\s\S]*?\/>/g, '')
+      // ClickToPlayVideo is excluded: it is converted above, and this pattern spans newlines, so
+      // without the guard it could swallow a video reference (or the prose between two of them).
+      .replace(/<(?!ClickToPlayVideo\b)[A-Z]\w+\s+[\s\S]*?\/>/g, '')
       // Convert <b> to bold
       .replace(/<b>([\s\S]*?)<\/b>/g, '**$1**')
       // Convert <i> to italic

--- a/src/components/ChapterVideo.tsx
+++ b/src/components/ChapterVideo.tsx
@@ -7,8 +7,12 @@ export type ChapterVideoProps = {
   title: string;
   /** Human readable runtime, e.g. "3:09". */
   duration: string;
-  /** Optional poster still — lazily loaded, so it costs nothing on initial render. */
-  poster?: string | null;
+  /**
+   * Optional first-frame still, shown in the facade before the video is fetched. Loaded with the
+   * page (unlike the MP4) since it costs a few KB, not tens of megabytes. Never passed to the
+   * native `poster` attribute — the facade renders it as an <img> instead.
+   */
+  previewImage?: string | null;
 };
 
 type Status = 'idle' | 'loading' | 'playing' | 'error';
@@ -26,7 +30,7 @@ const players = new Set<HTMLVideoElement>();
  * stack, which is what mobile Safari requires) but carries no `src` and no `poster` attribute, so
  * `preload="none"` has nothing to fetch. A CSS facade covers it until playback actually begins.
  */
-export function ChapterVideo({ src, title, duration, poster }: ChapterVideoProps) {
+export function ChapterVideo({ src, title, duration, previewImage }: ChapterVideoProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [status, setStatus] = useState<Status>('idle');
 
@@ -91,15 +95,14 @@ export function ChapterVideo({ src, title, duration, poster }: ChapterVideoProps
               status === 'loading' && 'pointer-events-none'
             )}
           >
-            {poster ? (
+            {previewImage ? (
               <>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={poster}
-                  alt=""
+                  src={previewImage}
+                  alt={`First frame of "${title}"`}
                   loading="lazy"
                   decoding="async"
-                  aria-hidden="true"
                   className="absolute inset-0 h-full w-full object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-zinc-950/80 via-zinc-950/30 to-zinc-950/50" />

--- a/src/components/ClickToPlayVideo.tsx
+++ b/src/components/ClickToPlayVideo.tsx
@@ -8,9 +8,9 @@ export type ClickToPlayVideoProps = {
   /** Human readable runtime, e.g. "3:09". */
   duration: string;
   /**
-   * Optional first-frame still, shown in the facade before the video is fetched. Loaded with the
-   * page (unlike the MP4) since it costs a few KB, not tens of megabytes. Never passed to the
-   * native `poster` attribute — the facade renders it as an <img> instead.
+   * Optional first-frame still, shown in the facade before the video is fetched. Lazily loaded as
+   * the facade approaches the viewport; unlike the MP4, it does not wait for a click. Never passed
+   * to the native `poster` attribute — the facade renders it as an <img> instead.
    */
   previewImage?: string | null;
 };

--- a/src/components/ClickToPlayVideo.tsx
+++ b/src/components/ClickToPlayVideo.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useCallback, useRef, useState } from 'react';
 
-export type ChapterVideoProps = {
+export type ClickToPlayVideoProps = {
   /** Absolute URL of the MP4. Never attached to the <video> until the visitor asks for it. */
   src: string;
   title: string;
@@ -30,7 +30,7 @@ const players = new Set<HTMLVideoElement>();
  * stack, which is what mobile Safari requires) but carries no `src` and no `poster` attribute, so
  * `preload="none"` has nothing to fetch. A CSS facade covers it until playback actually begins.
  */
-export function ChapterVideo({ src, title, duration, previewImage }: ChapterVideoProps) {
+export function ClickToPlayVideo({ src, title, duration, previewImage }: ClickToPlayVideoProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [status, setStatus] = useState<Status>('idle');
 

--- a/src/pages/portfolio/apotheneum/chapters.ts
+++ b/src/pages/portfolio/apotheneum/chapters.ts
@@ -9,14 +9,14 @@ export type Chapter = {
   /** Absolute URL of the MP4 on the media host. */
   src: string;
   /**
-   * Optional poster still. None exist yet; when one is added it is lazily loaded, so it never
-   * costs anything on initial render. Store posters alongside the video in R2.
+   * Absolute URL of the first-frame preview still, shown in the facade before the video is
+   * fetched. Object keys are versioned like the videos — see docs/media-pipeline.md.
    */
-  poster?: string | null;
+  previewImage: string;
 };
 
-function chapter(id: string, title: string, duration: string, objectKey: string, poster?: string | null): Chapter {
-  return { id, title, duration, src: mediaUrl(objectKey), poster: poster ?? null };
+function chapter(id: string, title: string, duration: string, objectKey: string, previewImageKey: string): Chapter {
+  return { id, title, duration, src: mediaUrl(objectKey), previewImage: mediaUrl(previewImageKey) };
 }
 
 /**
@@ -24,11 +24,41 @@ function chapter(id: string, title: string, duration: string, objectKey: string,
  * `immutable` cache-control on the bucket stays correct — re-exporting a chapter means a new key.
  */
 export const chapters = {
-  hyperspace: chapter('hyperspace', 'Hyperspace — Entry', '5:10', 'apotheneum/01-hyperspace-v2.mp4'),
-  'night-chorus': chapter('night-chorus', 'Night Chorus — Nocturnal Forest', '4:06', 'apotheneum/02-night-chorus.mp4'),
-  rain: chapter('rain', 'Rain — Canopy Weather', '3:09', 'apotheneum/03-rain.mp4'),
-  thunderstorm: chapter('thunderstorm', 'Thunderstorm — Peak Drama', '3:07', 'apotheneum/04-thunderstorm.mp4'),
-  sunrise: chapter('sunrise', 'Sunrise — Resolution', '3:48', 'apotheneum/05-sunrise.mp4'),
+  hyperspace: chapter(
+    'hyperspace',
+    'Hyperspace — Entry',
+    '5:10',
+    'apotheneum/01-hyperspace-v2.mp4',
+    'apotheneum/previews/01-hyperspace-first-frame-v1.avif'
+  ),
+  'night-chorus': chapter(
+    'night-chorus',
+    'Night Chorus — Nocturnal Forest',
+    '4:06',
+    'apotheneum/02-night-chorus.mp4',
+    'apotheneum/previews/02-night-chorus-first-frame-v1.avif'
+  ),
+  rain: chapter(
+    'rain',
+    'Rain — Canopy Weather',
+    '3:09',
+    'apotheneum/03-rain.mp4',
+    'apotheneum/previews/03-rain-first-frame-v1.avif'
+  ),
+  thunderstorm: chapter(
+    'thunderstorm',
+    'Thunderstorm — Peak Drama',
+    '3:07',
+    'apotheneum/04-thunderstorm.mp4',
+    'apotheneum/previews/04-thunderstorm-first-frame-v1.avif'
+  ),
+  sunrise: chapter(
+    'sunrise',
+    'Sunrise — Resolution',
+    '3:48',
+    'apotheneum/05-sunrise.mp4',
+    'apotheneum/previews/05-sunrise-first-frame-v1.avif'
+  ),
 } satisfies Record<string, Chapter>;
 
 export type ChapterId = keyof typeof chapters;

--- a/src/pages/portfolio/apotheneum/index.mdx
+++ b/src/pages/portfolio/apotheneum/index.mdx
@@ -1,6 +1,6 @@
 import { PortfolioPageLayout } from '@/components/PortfolioPageLayout'
 import { YouTube } from '@/components/partials'
-import { ChapterVideo } from '@/components/ChapterVideo'
+import { ClickToPlayVideo } from '@/components/ClickToPlayVideo'
 import { chapters } from './chapters'
 import { meta } from './meta'
 
@@ -47,7 +47,7 @@ The field recordings play through [Bitwig](https://bitwig.com), where all the tr
 
 Visitors enter through a tunnel of 5,000 particles streaking past — a star field that pulls them out of the desert and into the experience. The sound is built on a modified version of Polarity's [Some Chords](https://www.youtube.com/watch?v=wzozVVbSbhE) patch. Every keypress randomly shifts the direction of travel through hyperspace and swaps the color palette. Arpeggiated keys trigger the stars to shimmer.
 
-<ChapterVideo {...chapters.hyperspace} />
+<ClickToPlayVideo {...chapters.hyperspace} />
 
 ### Night Chorus — Nocturnal Forest
 
@@ -55,19 +55,19 @@ The space fills with nocturnal insects and frogs recorded deep in the Congo Basi
 
 Then the scene shifts into hallucination. The trees begin to deform kaleidoscopically — 3D polar coordinate transformations warping the forest into something between a painting and a dream, alive and unstable. The moon drifts from its axis and starts to move.
 
-<ChapterVideo {...chapters['night-chorus']} />
+<ClickToPlayVideo {...chapters['night-chorus']} />
 
 ### Rain — Canopy Weather
 
 Rain begins to fall through the canopy. Frogs call from the understory — envelope followers on their sounds drive the generation, each croak triggering ripples of light that trace paths down the walls of the cylinder. A kaleidoscopic pattern fills the scene, the rain and the forest deforming together.
 
-<ChapterVideo {...chapters.rain} />
+<ClickToPlayVideo {...chapters.rain} />
 
 ### Thunderstorm — Peak Drama
 
 Thunder recorded in the Amazon drives this scene. Envelope followers on the thunder sounds trigger randomized lightning patterns that crack across all four canvases — each strike generated from a different algorithm. The haptic bed translates the low frequencies into a rumbling sensation.
 
-<ChapterVideo {...chapters.thunderstorm} />
+<ClickToPlayVideo {...chapters.thunderstorm} />
 
 ### Sunrise — Resolution
 
@@ -75,7 +75,7 @@ The storm clears and night gives way to dawn. Birds emerge, flocking algorithms 
 
 The birds continue as the scene gives way to a morning glow driven by Agnes Pelton's [_Awakening_](https://sam.nmartmuseum.org/objects/15773/awakening) — a landscape with a golden trumpet in the sky, stars at left, and purple and brown mountains whose silhouette traces the profile of her father's face. An orb pulses at the center. The background image slowly deforms and pixelates until the piece ends.
 
-<ChapterVideo {...chapters.sunrise} />
+<ClickToPlayVideo {...chapters.sunrise} />
 
 ## The Patterns
 


### PR DESCRIPTION
Closes #46.

## Summary
- render first-frame AVIF previews in each ChapterVideo click facade
- keep native video elements free of src and poster until activation
- resolve preview URLs through mediaUrl() using immutable R2 object keys
- extend verify:media and document the extraction/upload/linking workflow

## Media
Five 1280x720 AVIF previews were extracted, visually checked, uploaded to danoved-media under apotheneum/previews/*-first-frame-v1.avif, and verified through media.danoved.xyz with immutable caching and matching SHA-256 downloads.

## Validation
- Prettier applied to all changed files
- git diff --check passes
- Full build and verify:media deferred to PR checks / follow-up review

Implementation was performed by Claude Sonnet in the dedicated worktree; Codex handled extraction, Cloudflare upload, verification, branch isolation, and PR preparation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `ChapterVideo` to `ClickToPlayVideo`, promotes the optional `poster` prop to a required `previewImage` field on `Chapter`, and wires up five AVIF first-frame stills (one per chapter) sourced from R2 through `mediaUrl()`. Documentation and the static verifier script are updated in step to reflect the new component name and the new preview-image invariants.

- **Component rename & prop promotion**: `ChapterVideo` → `ClickToPlayVideo`, `poster?: string | null` → `previewImage: string` on the `Chapter` type; the component prop stays optional for standalone use.
- **Accessibility improvement**: the preview `<img>` gains a meaningful `alt` (`First frame of "…"`) and loses `aria-hidden="true"`, so screen-reader users receive a useful description of the still.
- **Verifier extended**: `verify-chapter-videos.ts` gains checks that each chapter's preview key is present in `chapters.ts`, that the image is rendered as an `<img>` (not a native poster), that alt text is non-empty, and that the prerendered HTML includes the preview URL for every chapter.

<h3>Confidence Score: 5/5</h3>

Clean rename and feature addition with no behavioural regressions — safe to merge.

All changes are consistent: the component rename, prop promotion, preview key wiring, verifier extension, and documentation all agree. The previewImage type is required on Chapter and optional on the component, which is intentional for standalone use. The accessibility change is correct. No eager network requests are introduced and the existing mobile-Safari activation path is untouched.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ClickToPlayVideo.tsx | Renamed from ChapterVideo.tsx; `poster` replaced by `previewImage` with meaningful alt text and lazy loading; no eager video requests introduced. |
| src/pages/portfolio/apotheneum/chapters.ts | `previewImage` promoted to required `string` on `Chapter`; five AVIF preview keys added via `mediaUrl()` — no hardcoded hosts. |
| scripts/verify-chapter-videos.ts | Extended to verify preview image keys, alt text correctness, and prerendered HTML includes preview URLs; all checks align with the updated component contract. |
| src/api/llmsContent.ts | Straightforward rename of `convertChapterVideos` → `convertClickToPlayVideos` and the companion regex guard; LLM text output is unaffected. |
| src/pages/portfolio/apotheneum/index.mdx | Import and all five embed usages updated from ChapterVideo to ClickToPlayVideo; no content changes. |
| docs/media-pipeline.md | New section 3 documents the ffmpeg extraction, R2 upload, and linking workflow for preview images; existing sections renumbered and updated to match ClickToPlayVideo. |
| AGENTS.md | One-line update: `ChapterVideo` → `ClickToPlayVideo` in the no-eager-request rule. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant ClickToPlayVideo
    participant R2 as media.danoved.xyz (R2)

    Note over Browser,R2: Page load — zero MP4 requests
    Browser->>ClickToPlayVideo: render (previewImage src set, video src absent)
    ClickToPlayVideo->>R2: GET previewImage AVIF (lazy, on viewport entry)
    R2-->>Browser: AVIF still (immutable cache)

    Note over Browser,R2: Visitor clicks play
    Browser->>ClickToPlayVideo: click → activate()
    ClickToPlayVideo->>ClickToPlayVideo: "video.src = src (synchronous)"
    ClickToPlayVideo->>ClickToPlayVideo: video.play() (same gesture stack)
    ClickToPlayVideo->>R2: GET chapter MP4 (byte-range streaming)
    R2-->>Browser: MP4 stream
    ClickToPlayVideo->>ClickToPlayVideo: "onPlaying → status = 'playing' → facade unmounts"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Clarify lazy preview loading"](https://github.com/oveddan/site/commit/e6d652f2d023b42827439eb6b0f1e99f4a4f3546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48932911)</sub>

<!-- /greptile_comment -->