### PR TITLE
Replace malformed Apotheneum chapter videos

### DIFF
--- a/docs/media-pipeline.md
+++ b/docs/media-pipeline.md
@@ -148,13 +148,18 @@ All five current objects were verified this way against `media.danoved.xyz`; byt
 
 ## Current object keys
 
-| Chapter id     | Video object key                  | Preview image object key                                  | Runtime |
-| -------------- | --------------------------------- | --------------------------------------------------------- | ------- |
-| `hyperspace`   | `apotheneum/01-hyperspace-v2.mp4` | `apotheneum/previews/01-hyperspace-first-frame-v1.avif`   | 5:10    |
-| `night-chorus` | `apotheneum/02-night-chorus.mp4`  | `apotheneum/previews/02-night-chorus-first-frame-v1.avif` | 4:06    |
-| `rain`         | `apotheneum/03-rain.mp4`          | `apotheneum/previews/03-rain-first-frame-v1.avif`         | 3:09    |
-| `thunderstorm` | `apotheneum/04-thunderstorm.mp4`  | `apotheneum/previews/04-thunderstorm-first-frame-v1.avif` | 3:07    |
-| `sunrise`      | `apotheneum/05-sunrise.mp4`       | `apotheneum/previews/05-sunrise-first-frame-v1.avif`      | 3:48    |
+| Chapter id     | Video object key                    | Preview image object key                                  | Runtime |
+| -------------- | ----------------------------------- | --------------------------------------------------------- | ------- |
+| `hyperspace`   | `apotheneum/01-hyperspace-v2.mp4`   | `apotheneum/previews/01-hyperspace-first-frame-v1.avif`   | 5:10    |
+| `night-chorus` | `apotheneum/02-night-chorus-v2.mp4` | `apotheneum/previews/02-night-chorus-first-frame-v1.avif` | 4:06    |
+| `rain`         | `apotheneum/03-rain.mp4`            | `apotheneum/previews/03-rain-first-frame-v1.avif`         | 3:09    |
+| `thunderstorm` | `apotheneum/04-thunderstorm-v2.mp4` | `apotheneum/previews/04-thunderstorm-first-frame-v1.avif` | 3:07    |
+| `sunrise`      | `apotheneum/05-sunrise-v2.mp4`      | `apotheneum/previews/05-sunrise-first-frame-v1.avif`      | 3:48    |
+
+The unversioned Night Chorus, Thunderstorm, and Sunrise objects are retained only as historical
+objects and must not be used: their uploads were truncated and do not contain a valid `moov` atom.
+The `v2` replacements above were packet-scanned, decode-tested at the beginning/middle/end, checked
+for `moov`-before-`mdat`, and checksum-verified after upload.
 
 ## How the player behaves
 

--- a/scripts/verify-chapter-videos.ts
+++ b/scripts/verify-chapter-videos.ts
@@ -22,10 +22,20 @@ type ExpectedChapter = [id: string, key: string, duration: string, previewKey: s
 
 const EXPECTED: ExpectedChapter[] = [
   ['hyperspace', 'apotheneum/01-hyperspace-v2.mp4', '5:10', 'apotheneum/previews/01-hyperspace-first-frame-v1.avif'],
-  ['night-chorus', 'apotheneum/02-night-chorus.mp4', '4:06', 'apotheneum/previews/02-night-chorus-first-frame-v1.avif'],
+  [
+    'night-chorus',
+    'apotheneum/02-night-chorus-v2.mp4',
+    '4:06',
+    'apotheneum/previews/02-night-chorus-first-frame-v1.avif',
+  ],
   ['rain', 'apotheneum/03-rain.mp4', '3:09', 'apotheneum/previews/03-rain-first-frame-v1.avif'],
-  ['thunderstorm', 'apotheneum/04-thunderstorm.mp4', '3:07', 'apotheneum/previews/04-thunderstorm-first-frame-v1.avif'],
-  ['sunrise', 'apotheneum/05-sunrise.mp4', '3:48', 'apotheneum/previews/05-sunrise-first-frame-v1.avif'],
+  [
+    'thunderstorm',
+    'apotheneum/04-thunderstorm-v2.mp4',
+    '3:07',
+    'apotheneum/previews/04-thunderstorm-first-frame-v1.avif',
+  ],
+  ['sunrise', 'apotheneum/05-sunrise-v2.mp4', '3:48', 'apotheneum/previews/05-sunrise-first-frame-v1.avif'],
 ];
 
 // 1. Chapter metadata is the single source of truth, and hosts are never hardcoded.

--- a/src/pages/portfolio/apotheneum/chapters.ts
+++ b/src/pages/portfolio/apotheneum/chapters.ts
@@ -35,7 +35,7 @@ export const chapters = {
     'night-chorus',
     'Night Chorus — Nocturnal Forest',
     '4:06',
-    'apotheneum/02-night-chorus.mp4',
+    'apotheneum/02-night-chorus-v2.mp4',
     'apotheneum/previews/02-night-chorus-first-frame-v1.avif'
   ),
   rain: chapter(
@@ -49,14 +49,14 @@ export const chapters = {
     'thunderstorm',
     'Thunderstorm — Peak Drama',
     '3:07',
-    'apotheneum/04-thunderstorm.mp4',
+    'apotheneum/04-thunderstorm-v2.mp4',
     'apotheneum/previews/04-thunderstorm-first-frame-v1.avif'
   ),
   sunrise: chapter(
     'sunrise',
     'Sunrise — Resolution',
     '3:48',
-    'apotheneum/05-sunrise.mp4',
+    'apotheneum/05-sunrise-v2.mp4',
     'apotheneum/previews/05-sunrise-first-frame-v1.avif'
   ),
 } satisfies Record<string, Chapter>;


### PR DESCRIPTION
## Summary
- point Night Chorus, Thunderstorm, and Sunrise at new immutable v2 R2 objects
- keep the current shortened 3:48 Sunrise edit
- update the media verifier and runbook with the repaired keys and the malformed-object incident

## Media validation
- local full-file packet scan and ffprobe passed
- H.264 High, 1920x1080 at 30000/1001 fps
- AAC-LC stereo at 48 kHz
- moov precedes mdat in all three files
- beginning, middle, and end video/audio decode tests passed
- public custom-domain ffprobe, exact content length, byte ranges, and immutable cache metadata passed
- full public downloads matched local SHA-256 checksums

## Public objects
- https://media.danoved.xyz/apotheneum/02-night-chorus-v2.mp4
- https://media.danoved.xyz/apotheneum/04-thunderstorm-v2.mp4
- https://media.danoved.xyz/apotheneum/05-sunrise-v2.mp4

## Checks
- `fnm exec --using=24 pnpm build`
- `fnm exec --using=24 pnpm verify:media`
- `git diff --check`

The valid completed local exports already existed as Dropbox conflicted copies, so no editorial re-export or Premiere mutation was needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces three malformed (truncated, missing `moov` atom) Apotheneum chapter video objects with validated v2 replacements on R2, updating the three locations that reference the object keys: the chapter source-of-truth, the static verifier, and the runbook table.

- `chapters.ts` — three keys changed: `02-night-chorus.mp4` → `02-night-chorus-v2.mp4`, `04-thunderstorm.mp4` → `04-thunderstorm-v2.mp4`, `05-sunrise.mp4` → `05-sunrise-v2.mp4`; rain and hyperspace (already v2) are untouched.
- `verify-chapter-videos.ts` — EXPECTED array updated to match the new keys; all verification logic is unchanged.
- `docs/media-pipeline.md` — key table updated and a note added warning that the old unversioned objects are malformed and must not be reused.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward replacement of three object key strings with validated v2 counterparts, applied consistently across all three files that reference them.

The key update is identical in all three files with no discrepancies. The unversioned chapters (rain) and the already-versioned chapter (hyperspace) are correctly left unchanged. The verifier logic itself is untouched — only its expected-key table is updated. No edge case or regression risk is apparent.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/pages/portfolio/apotheneum/chapters.ts | Three chapter video keys updated from unversioned to v2; all other fields unchanged and correct. |
| scripts/verify-chapter-videos.ts | EXPECTED table updated to match the new v2 keys; rain and hyperspace entries correctly left unchanged. No logic changes. |
| docs/media-pipeline.md | Object key table updated to v2 keys; adds a note that old unversioned objects are malformed and must not be reused. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chapters.ts\nsource of truth] -->|objectKey| B[mediaUrl helper]
    B -->|absolute URL| C[ClickToPlayVideo\nplayer component]
    C -->|on click| D[R2 / media.danoved.xyz]

    subgraph "Updated keys (this PR)"
        K1[02-night-chorus-v2.mp4]
        K2[04-thunderstorm-v2.mp4]
        K3[05-sunrise-v2.mp4]
    end

    subgraph "Unchanged keys"
        K4[01-hyperspace-v2.mp4]
        K5[03-rain.mp4]
    end

    A --- K1
    A --- K2
    A --- K3
    A --- K4
    A --- K5

    E[verify-chapter-videos.ts] -->|reads & checks| A
    F[docs/media-pipeline.md] -->|documents| D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Replace malformed Apotheneum chapter vid..."](https://github.com/oveddan/site/commit/9598c4b3dad81e77bb13328eaa89a08891cd0f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48937325)</sub>

<!-- /greptile_comment -->