### PR TITLE
Pause a chapter video when it scrolls out of view

### DIFF
--- a/src/components/ClickToPlayVideo.tsx
+++ b/src/components/ClickToPlayVideo.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type ClickToPlayVideoProps = {
   /** Absolute URL of the MP4. Never attached to the <video> until the visitor asks for it. */
@@ -32,13 +32,32 @@ const players = new Set<HTMLVideoElement>();
  */
 export function ClickToPlayVideo({ src, title, duration, previewImage }: ClickToPlayVideoProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [videoEl, setVideoEl] = useState<HTMLVideoElement | null>(null);
   const [status, setStatus] = useState<Status>('idle');
 
   const setVideoRef = useCallback((node: HTMLVideoElement | null) => {
     if (videoRef.current) players.delete(videoRef.current);
     videoRef.current = node;
     if (node) players.add(node);
+    setVideoEl(node);
   }, []);
+
+  // Scrolling a playing chapter fully out of view pauses it. Without this, audio from a chapter
+  // the visitor has left behind keeps running under the rest of the page. The playhead is kept, so
+  // scrolling back and pressing play resumes where they were.
+  useEffect(() => {
+    if (!videoEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting && !videoEl.paused) videoEl.pause();
+      },
+      { threshold: 0 }
+    );
+
+    observer.observe(videoEl);
+    return () => observer.disconnect();
+  }, [videoEl]);
 
   // Synchronous: assign the source and call play() in the same user-gesture stack. Deferring
   // either to an effect loses the gesture and playback is blocked on iOS.


### PR DESCRIPTION
## The bug

On the Apotheneum page, playing a chapter video and scrolling away left its audio running under the rest of the page.

`ClickToPlayVideo` had **no viewport handling at all**. Once started, a player only stopped when another player started, when the visitor paused it, when it ended, or on unmount. Scrolling was not one of those.

The original report also suspected the pause-others coordination was broken ("even if you click play on a different video"). It isn't — `pauseOthers` on `onPlay` walks the module-scope `players` set correctly, and all five chapters come from a single import so the set is genuinely shared. That path is unchanged here.

## The fix

Observe each `<video>` with an `IntersectionObserver` and pause it once it leaves the viewport entirely (`threshold: 0`).

It **pauses rather than resets**, so the playhead survives — scrolling back and pressing play resumes where the visitor left off.

The ref callback also sets a `videoEl` state value, because the effect needs to re-run when the element attaches; a plain `useRef` would not trigger it.

## Guarantees preserved

The AGENTS.md rule that a `ClickToPlayVideo` makes **no MP4 request before a click** still holds: the observer only ever calls `pause()`. It never assigns `src`, never sets `poster`, and never touches `preload`.

## Verification

- `pnpm build` — passes
- `pnpm verify:media` — `chapter-video verification passed`

**Not yet verified in a real browser.** The scroll-away behavior itself has only been reasoned about statically. The Netlify deploy preview on this PR is the first real confirmation — worth scrolling past one playing chapter before merging.

## Known, deliberate non-fix

A video paused *by another video starting* keeps `status === 'playing'`, since there is no `onPause`/`onEnded` handler, so its facade never returns. Resetting to the facade on pause would hide the native controls and scrub position mid-viewing, which is a worse outcome than the stale status. Left as-is on purpose.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug on the Apotheneum page where a playing chapter video's audio continued running after the user scrolled away. The fix attaches an `IntersectionObserver` to each `<video>` element that calls `pause()` the moment the element leaves the viewport entirely, preserving the playhead so users can resume from the same position.

- `useState` is used alongside the existing `useRef` to hold the video element, so the `useEffect` re-runs when the element attaches — a necessary workaround for the fact that `useRef` changes do not trigger effects.
- Observer cleanup (`observer.disconnect()`) is correctly performed in the effect's return function, covering both component unmount and any `videoEl` identity change.
- The pre-click zero-network-request guarantee is preserved: the observer only calls `pause()` and never touches `src`, `poster`, or `preload`.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — it adds a small, self-contained observer with correct cleanup and does not touch any existing logic paths.

The logic is sound: the observer fires only client-side via useEffect, cleanup via disconnect() is present, and the dual videoRef/videoEl pattern correctly handles the need to re-run the effect on element attachment. The one open question is that the author notes real-browser scroll testing has not happened yet — the Netlify preview is the first live confirmation.

**Files Needing Attention:** Only src/components/ClickToPlayVideo.tsx changed; the manual scroll-then-play flow on the Apotheneum deploy preview is worth a quick check before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ClickToPlayVideo.tsx | Adds IntersectionObserver-based auto-pause when the video scrolls fully out of view; uses a videoEl state mirror of the ref to trigger the effect re-run on mount — implementation is correct and cleanup is sound. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component mounts, video el attaches] --> B[setVideoRef callback runs]
    B --> B1[Adds node to players set]
    B --> B2[setVideoEl node triggers re-render]
    B2 --> C[useEffect fires on videoEl change]
    C --> D[IntersectionObserver created with threshold 0]
    D --> E{Intersection event fires}
    E -- isIntersecting true --> F[No action]
    E -- isIntersecting false --> G{videoEl.paused?}
    G -- true --> F
    G -- false --> H[videoEl.pause called]
    H --> I[Audio stops, playhead preserved]
    C --> J[Cleanup on unmount or videoEl change]
    J --> K[observer.disconnect]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22oveddan%2Fsite%22%20on%20the%20existing%20branch%20%22fix%2Fpause-chapter-video-on-scroll-away%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpause-chapter-video-on-scroll-away%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcomponents%2FClickToPlayVideo.tsx%3A51-56%0AThe%20%60%7B%20threshold%3A%200%20%7D%60%20options%20object%20is%20the%20%60IntersectionObserver%60%20default%20%28the%20spec%20initialises%20%60thresholds%60%20to%20%60%5B0%5D%60%20when%20the%20option%20is%20omitted%29%2C%20so%20passing%20it%20explicitly%20has%20no%20runtime%20effect.%20The%20comment%20already%20explains%20the%20intent%20clearly%20enough%20that%20the%20option%20can%20be%20dropped%2C%20or%20it%20can%20stay%20as%20an%20explicit%20self-document%20of%20the%20%22fully%20out%20of%20view%22%20intent%20%E2%80%94%20either%20is%20fine%2C%20but%20it's%20worth%20knowing%20it's%20redundant.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20observer%20%3D%20new%20IntersectionObserver%28%28%5Bentry%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20if%20%28!entry.isIntersecting%20%26%26%20!videoEl.paused%29%20videoEl.pause%28%29%3B%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=oveddan%2Fsite&pr=50&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcomponents%2FClickToPlayVideo.tsx%3A51-56%0AThe%20%60%7B%20threshold%3A%200%20%7D%60%20options%20object%20is%20the%20%60IntersectionObserver%60%20default%20%28the%20spec%20initialises%20%60thresholds%60%20to%20%60%5B0%5D%60%20when%20the%20option%20is%20omitted%29%2C%20so%20passing%20it%20explicitly%20has%20no%20runtime%20effect.%20The%20comment%20already%20explains%20the%20intent%20clearly%20enough%20that%20the%20option%20can%20be%20dropped%2C%20or%20it%20can%20stay%20as%20an%20explicit%20self-document%20of%20the%20%22fully%20out%20of%20view%22%20intent%20%E2%80%94%20either%20is%20fine%2C%20but%20it's%20worth%20knowing%20it's%20redundant.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20observer%20%3D%20new%20IntersectionObserver%28%28%5Bentry%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20if%20%28!entry.isIntersecting%20%26%26%20!videoEl.paused%29%20videoEl.pause%28%29%3B%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=oveddan%2Fsite&pr=50&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/components/ClickToPlayVideo.tsx:51-56
The `{ threshold: 0 }` options object is the `IntersectionObserver` default (the spec initialises `thresholds` to `[0]` when the option is omitted), so passing it explicitly has no runtime effect. The comment already explains the intent clearly enough that the option can be dropped, or it can stay as an explicit self-document of the "fully out of view" intent — either is fine, but it's worth knowing it's redundant.

```suggestion
    const observer = new IntersectionObserver(([entry]) => {
      if (!entry.isIntersecting && !videoEl.paused) videoEl.pause();
    });
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Pause a chapter video when it scrolls ou..."](https://github.com/oveddan/site/commit/87c88d65331ae45a9047cb2b6f90a418416d5bb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49259126)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->